### PR TITLE
Fix typo with storageclass reference in templates

### DIFF
--- a/charts/vsphere-cpi-csi/v1.0.2/templates/storageclass.yaml
+++ b/charts/vsphere-cpi-csi/v1.0.2/templates/storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storageClass  }}
+{{- if .Values.storageclass  }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/charts/vsphere-cpi-csi/v2.0.0/templates/storageclass.yaml
+++ b/charts/vsphere-cpi-csi/v2.0.0/templates/storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storageClass  }}
+{{- if .Values.storageclass  }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:


### PR DESCRIPTION
StorageClass yaml is not rendered because the if condition doesn't match the storageclass in values.yaml

Signed-off-by: Pradip Caulagi <caulagi@gmail.com>
