### PR TITLE
Make deployment of csi-resizer container a parameter

### DIFF
--- a/charts/vsphere-cpi-csi/v2.0.0/Chart.yaml
+++ b/charts/vsphere-cpi-csi/v2.0.0/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vsphere-cpi-csi
-version: 2.0.0
+version: 2.1.0
 appVersion: 2.0.0
 description: vSphere CPI manager and CSI drivers
 keywords:

--- a/charts/vsphere-cpi-csi/v2.0.0/questions.yml
+++ b/charts/vsphere-cpi-csi/v2.0.0/questions.yml
@@ -121,3 +121,7 @@ questions:
         type: string
         required: false
         group: "storageClass"
+  - variable: deployCSIResizer
+    default: true
+    label: Should the csi-resizer container be deployed (Not supported on VSphere 6.7U3)
+    type: boolean

--- a/charts/vsphere-cpi-csi/v2.0.0/templates/vsphere-csi-controller-deployment.yaml
+++ b/charts/vsphere-cpi-csi/v2.0.0/templates/vsphere-csi-controller-deployment.yaml
@@ -46,6 +46,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+        {{ if .Values.deployCSIResizer -}}
         - name: csi-resizer
           image: {{ .Values.images.csiResizer }}
           args:
@@ -59,6 +60,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+        {{ end -}}
         - name: vsphere-csi-controller
           image: {{ .Values.images.csiDriver }}
           lifecycle:

--- a/charts/vsphere-cpi-csi/v2.0.0/values.yaml
+++ b/charts/vsphere-cpi-csi/v2.0.0/values.yaml
@@ -21,3 +21,5 @@ storageclass:
   fstype: ext4
   # storagepolicyname: my-storage-policy
   # datastoreurl: ds:///vmfs/volumes/vsan:528c27f173c2088e-2126e911985dc3aa/
+
+deployCSIResizer: true


### PR DESCRIPTION
This change makes the helm chart compatible with VSphere 6.7U3 by making the deployment of csi-resizer optional as this component is VSphere 7.x only