### PR TITLE
added support for reclaimPolicy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the vSphere CPI+CSIchar
 | `storageclass.fstype`                    | Filesystem type to use e.g. `ext4` or `file` (v2.0.0 only) | ext4 |
 | `storageclass.storagepolicyname`         | Storagepolicy name to use if given | my-storage-policy |
 | `storageclass.datastoreurl`              | Optional datastore url     | |
+| `storageclass.reclaimpolicy`             | Optional reclaim policy    | Delete |
 
 > **Tip**: In addition all settings used in the [vSphere CPI helm chart](https://github.com/helm/charts/tree/master/stable/vsphere-cpi) are also useable in this chart.
 

--- a/charts/vsphere-cpi-csi/v1.0.2/questions.yml
+++ b/charts/vsphere-cpi-csi/v1.0.2/questions.yml
@@ -116,3 +116,9 @@ questions:
         type: string
         required: false
         group: "storageClass"
+      - variable: storageclass.reclaimpolicy
+        label: storageClass reclaim policy
+        default: "Delete"
+        type: string
+        required: false
+        group: "storageClass"

--- a/charts/vsphere-cpi-csi/v1.0.2/templates/storageclass.yaml
+++ b/charts/vsphere-cpi-csi/v1.0.2/templates/storageclass.yaml
@@ -14,4 +14,7 @@ parameters:
  {{- if .Values.storageclass.storagepolicyname }}
  storagepolicyname: {{ .Values.storageclass.storagepolicyname | quote }}
  {{- end }}
+{{- if .Values.storageclass.reclaimpolicy }}
+reclaimPolicy: {{ .Values.storageclass.reclaimpolicy }}
+{{- end }}
 {{- end }}

--- a/charts/vsphere-cpi-csi/v2.0.0/questions.yml
+++ b/charts/vsphere-cpi-csi/v2.0.0/questions.yml
@@ -121,6 +121,12 @@ questions:
         type: string
         required: false
         group: "storageClass"
+      - variable: storageclass.reclaimpolicy
+        label: storageClass reclaim policy
+        default: "Delete"
+        type: string
+        required: false
+        group: "storageClass"
   - variable: deployCSIResizer
     default: true
     label: Should the csi-resizer container be deployed (Not supported on VSphere 6.7U3)

--- a/charts/vsphere-cpi-csi/v2.0.0/templates/storageclass.yaml
+++ b/charts/vsphere-cpi-csi/v2.0.0/templates/storageclass.yaml
@@ -14,4 +14,7 @@ parameters:
  {{- if .Values.storageclass.storagepolicyname }}
  storagepolicyname: {{ .Values.storageclass.storagepolicyname | quote }}
  {{- end }}
+{{- if .Values.storageclass.reclaimpolicy }}
+reclaimPolicy: {{ .Values.storageclass.reclaimpolicy }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Added support of [storageClass ReclaimPolicy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) setting, with the default set to Delete.
Tested Retain, Delete and no value on v1.0.2 chart with vCenter 6.7u3.