### PR TITLE
Make Kubelet path configurable

### DIFF
--- a/charts/vsphere-cpi-csi/v2.1.0/questions.yml
+++ b/charts/vsphere-cpi-csi/v2.1.0/questions.yml
@@ -82,6 +82,13 @@ questions:
     type: string
     required: true
     group: "vCenter"
+  - variable: kubelet.path
+    label: Kubelet path
+    description: "E.g. /var/lib/k0s/kubelet"
+    default: "/var/lib/kubelet"
+    type: string
+    required: true
+    group: "Kubelet"
   - variable: storageClass
     default: true
     label: Create matching storageClass

--- a/charts/vsphere-cpi-csi/v2.1.0/templates/vsphere-csi-node-ds.yaml
+++ b/charts/vsphere-cpi-csi/v2.1.0/templates/vsphere-csi-node-ds.yaml
@@ -30,7 +30,7 @@ spec:
         - name: ADDRESS
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
-          value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+          value: {{ .Values.kubelet.path }}/plugins/csi.vsphere.vmware.com/csi.sock
         securityContext:
           privileged: true
         volumeMounts:
@@ -88,7 +88,7 @@ spec:
         - name: plugin-dir
           mountPath: /csi
         - name: pods-mount-dir
-          mountPath: /var/lib/kubelet
+          mountPath: {{ .Values.kubelet.path }}
           # needed so that any mounts setup inside this container are
           # propagated back to the host machine.
           mountPropagation: "Bidirectional"
@@ -118,15 +118,15 @@ spec:
       #    secretName: vsphere-config-secret
       - name: registration-dir
         hostPath:
-          path: /var/lib/kubelet/plugins_registry
+          path: {{ .Values.kubelet.path }}/plugins_registry
           type: Directory
       - name: plugin-dir
         hostPath:
-          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com
+          path: {{ .Values.kubelet.path }}/plugins/csi.vsphere.vmware.com
           type: DirectoryOrCreate
       - name: pods-mount-dir
         hostPath:
-          path: /var/lib/kubelet
+          path: {{ .Values.kubelet.path }}
           type: Directory
       - name: device-dir
         hostPath:

--- a/charts/vsphere-cpi-csi/v2.1.0/values.yaml
+++ b/charts/vsphere-cpi-csi/v2.1.0/values.yaml
@@ -15,6 +15,9 @@ vcenter:
   # password: root
   # datacenter: DC1
 
+kubelet:
+  path: /var/lib/kubelet
+
 storageclass:
   name: vsphere-csi
   default: true


### PR DESCRIPTION
Added an option to make the Kubelet path configurable, since some Kubernetes distributions use a custom path such as `/var/lib/k0s/kubelet` in k0s or `/var/lib/rancher/k3s/agent/kubelet/` in k3s.