### PR TITLE
 Charts :: v2.1.0 :: fix storage.reclaimPolicy

### DIFF
--- a/charts/vsphere-cpi-csi/v2.1.0/templates/storageclass.yaml
+++ b/charts/vsphere-cpi-csi/v2.1.0/templates/storageclass.yaml
@@ -14,4 +14,7 @@ parameters:
  {{- if .Values.storageclass.storagepolicyname }}
  storagepolicyname: {{ .Values.storageclass.storagepolicyname | quote }}
  {{- end }}
+{{- if .Values.storageclass.reclaimpolicy }}
+reclaimPolicy: {{ .Values.storageclass.reclaimpolicy }}
+{{- end }}
 {{- end }}

--- a/charts/vsphere-cpi-csi/v2.1.0/values.yaml
+++ b/charts/vsphere-cpi-csi/v2.1.0/values.yaml
@@ -24,3 +24,4 @@ storageclass:
   fstype: ext4
   # storagepolicyname: my-storage-policy
   # datastoreurl: ds:///vmfs/volumes/vsan:528c27f173c2088e-2126e911985dc3aa/
+  # reclaimpolicy: Delete


### PR DESCRIPTION
Hello @stefanvangastel ,

Thank you . I used your v2.1.0 chart in the production environment and it worked successfully. ( 5 Control Plane and 5 worker nodes)

Just when defining the storageclass, the reclaimPolicy was always showing as 'DELETE' . Even set is with different values , like "Retain".

The reason was 'reclaimPolicy' variable was missing in template file for v2.1.0. I added it for you :)