### PR TITLE
New version with better value-driven deployments

### DIFF
--- a/charts/vsphere-cpi-csi/v2.3.0/Chart.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+name: vsphere-cpi-csi
+version: 2.3.0
+appVersion: 2.3.0
+description: vSphere CPI manager and CSI drivers
+keywords:
+  - vsphere
+  - vmware
+  - esxi
+  - cpi
+  - csi
+  - storage
+icon: file://../vsphere_7.png
+maintainers:
+  - name: Stefan van Gastel
+    email: stefanvangastel@gmail.com
+  - name: Tom Houweling
+    email: thouweling@gmail.com
+engine: gotpl

--- a/charts/vsphere-cpi-csi/v2.3.0/README.md
+++ b/charts/vsphere-cpi-csi/v2.3.0/README.md
@@ -1,0 +1,24 @@
+## Manual steps, existing cluster
+1. Merge the config below with your existing cluster config `kubelet` configuration (`Edit cluster -> Edit as YAML (Cluster options)`):
+  ```
+  kubelet:
+    extra_args:
+      cloud-provider: external
+    extra_binds:
+      - '/csi:/csi:rshared'
+      - '/var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com:/var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com:rshared'
+  ```
+2. Worker nodes **need** to have a `node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule` taint, this is only automatically applied to *new* nodes. Apply this taint manually to **existing** nodes.
+3. Deploy the chart in the **`kube-system`** namespace. 
+
+## Manual steps, new cluster
+1. When creating a new cluster, select the `External` cloudprovider. This way all deployed nodes will get the required taints.
+2. Merge the config below with the generated cluster config `kubelet` configuration (`Edit as YAML (Cluster options)`):
+  ```
+  kubelet:
+    extra_binds:
+      - '/csi:/csi:rshared'
+      - '/var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com:/var/lib/csi/sockets/pluginproxy/csi.vsphere.vmware.com:rshared'
+  ```
+3. Create you cluster.
+4. Deploy the chart in the **`kube-system`** namespace. 

--- a/charts/vsphere-cpi-csi/v2.3.0/app-readme.md
+++ b/charts/vsphere-cpi-csi/v2.3.0/app-readme.md
@@ -1,0 +1,13 @@
+## vSphere CPI v1.1.0 and CSI v2.0.0 and CSI v2.1.0
+
+This chart deploys both the vSphere CPI (Cloud Provider Interface) manager for vSphere as well as the CSI (Cloud Storage Interface) drivers and optional storageClass.
+
+It uses [upstream VMWare vSphere manifests](https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/master/manifests) with small tweaks to support Rancher RKE clusters. 
+
+**Pre-requirements:**
+
+* **vSphere 7.0+** 
+* Kubernetes cluster version **1.16+**
+* VM's with harware version 15+ and `vmtools` installed on all nodes
+* The `ubuntu` guest OS is recommended 
+* **Manual** steps are described in the `Detailed Description` below. 

--- a/charts/vsphere-cpi-csi/v2.3.0/questions.yml
+++ b/charts/vsphere-cpi-csi/v2.3.0/questions.yml
@@ -1,0 +1,130 @@
+labels:
+  io.cattle.role: cluster # options are cluster/project
+namespace: kube-system
+categories:
+  - storage
+questions:
+  - variable: defaultImage
+    default: true
+    label: Use default container images
+    type: boolean
+    show_subquestion_if: false
+    group: "Container Images"
+    subquestions:
+      - variable: images.vsphereCloudControllerManager
+        default: "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.1.0"
+        type: string
+        label: vsphere-cloud-controller-manager
+      - variable: images.csiAttacher
+        default: "quay.io/k8scsi/csi-attacher:v3.0.0"
+        type: string
+        label: csi-attacher
+      - variable: images.csiDriver
+        default: "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0"
+        type: string
+        label: vsphere-csi-controller
+      - variable: images.livenessProbe
+        default: "quay.io/k8scsi/livenessprobe:v2.1.0"
+        type: string
+        label: liveness-probe
+      - variable: images.vsphereSyncer
+        default: "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0"
+        type: string
+        label: vsphere-syncer
+      - variable: images.csiProvisioner
+        default: "quay.io/k8scsi/csi-provisioner:v2.0.0"
+        type: string
+        label: csi-provisioner
+      - variable: images.csiResizer
+        default: "quay.io/k8scsi/csi-resizer:v1.0.0"
+        type: string
+        label: csi-resizer
+      - variable: images.nodeDriverRegistrar
+        default: "quay.io/k8scsi/csi-node-driver-registrar:v2.0.1"
+        type: string
+        label: node-driver-registrar
+  - variable: vcenter.host
+    label: vCenter or ESXi Server
+    description: "e.g. vcenter.example.com"
+    default: ""
+    type: string
+    required: true
+    group: "vCenter"
+  - variable: vcenter.port
+    label: vCenter or ESXi Server port
+    default: "443"
+    type: int
+    required: true
+    group: "vCenter"
+  - variable: vcenter.insecurehost
+    label: Insecure host?
+    description: "Set to true if using self-signed cert for vCenter or ESXi Server"
+    default: "true"
+    type: boolean
+    required: true
+    group: "vCenter"
+  - variable: vcenter.username
+    label: vCenter username
+    default: ""
+    type: string
+    required: true
+    group: "vCenter"
+  - variable: vcenter.password
+    label: vCenter password
+    default: ""
+    type: password
+    required: true
+    group: "vCenter"
+  - variable: vcenter.datacenter
+    label: Data Center
+    description: "E.g. DC1"
+    default: ""
+    type: string
+    required: true
+    group: "vCenter"
+  - variable: kubelet.path
+    label: Kubelet path
+    description: "E.g. /var/lib/k0s/kubelet"
+    default: "/var/lib/kubelet"
+    type: string
+    required: true
+    group: "Kubelet"
+  - variable: storageClass
+    default: true
+    label: Create matching storageClass
+    type: boolean
+    show_subquestion_if: true
+    group: "storageClass"
+    subquestions:
+      - variable: storageclass.name
+        label: storageClass name
+        default: "vsphere-csi"
+        type: string
+        required: true
+        group: "storageClass"
+      - variable: storageclass.default
+        label: Make default storageClass?
+        default: "true"
+        type: boolean
+        required: true
+        group: "storageClass"
+      - variable: storageclass.fstype
+        label: Filesystem type
+        description: "Use 'nfs4' to use the File Volume type"
+        default: "ext4"
+        type: string
+        required: true
+        group: "storageClass"
+      - variable: storageclass.storagepolicyname
+        label: Storage Policy Name
+        default: ""
+        type: string
+        required: false
+        group: "storageClass"
+      - variable: storageclass.datastoreurl
+        label: Datastore URL (optional)
+        description: "E.g. ds:///vmfs/volumes/vsan:528c27f173c2088e-2126e911985dc3aa/"
+        default: ""
+        type: string
+        required: false
+        group: "storageClass"

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/_helpers.tpl
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vsphere-csi-cpi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vsphere-csi-cpi.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/cloud-controller-manager-role-bindings.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/cloud-controller-manager-role-bindings.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: servicecatalog.k8s.io:apiserver-authentication-reader
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: extension-apiserver-authentication-reader
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+  - apiGroup: ""
+    kind: User
+    name: cloud-controller-manager
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-controller-manager
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-controller-manager
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+  - kind: User
+    name: cloud-controller-manager
+kind: List
+metadata: {}

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/cloud-controller-manager-roles.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/cloud-controller-manager-roles.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:cloud-controller-manager
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - services/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+    - list
+    - watch
+kind: List
+metadata: {}

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/cloud-provider.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/cloud-provider.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vsphere-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: vsphere-cloud-controller-manager
+spec:
+  selector:
+    matchLabels:
+      k8s-app: vsphere-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: vsphere-cloud-controller-manager
+    spec:
+      nodeSelector:
+        {{- if .Values.cloudProvider.nodeSelector }}
+        {{- toYaml .Values.cloudProvider.nodeSelector | nindent 8 }}
+        {{- else }}
+        node-role.kubernetes.io/controlplane: "true"
+        {{- end }}
+      tolerations:
+        {{- if .Values.cloudProvider.tolerations }}
+        {{- toYaml .Values.cloudProvider.tolerations | nindent 8 }}
+        {{- else }}
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/controlplane
+          value: "true"
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/etcd
+          value: "true"
+          effect: NoExecute
+        {{- end }}
+      securityContext:
+        runAsUser: 0
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: vsphere-cloud-controller-manager
+          image: {{ .Values.images.vsphereCloudControllerManager }}
+          args:
+            - --v=2
+            - --cloud-provider=vsphere
+            - --cloud-config=/etc/cloud/cpi-vsphere.conf
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+      hostNetwork: true
+      volumes:
+      - name: vsphere-config-volume
+        configMap:
+          name: cloud-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: cloud-controller-manager
+  name: vsphere-cloud-controller-manager
+  namespace: kube-system
+spec:
+  type: NodePort
+  ports:
+    - port: 43001
+      protocol: TCP
+      targetPort: 43001
+  selector:
+    component: cloud-controller-manager

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/cpi-secret.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/cpi-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cpi-global-secret
+  namespace: kube-system
+stringData:
+  {{ .Values.vcenter.host }}.username: {{ .Values.vcenter.username | quote }}
+  {{ .Values.vcenter.host }}.password: {{ .Values.vcenter.password | quote }}

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/cpi-vsphere-cloud-config.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/cpi-vsphere-cloud-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-config
+  namespace: kube-system
+data:
+  cpi-vsphere.conf: |-
+    [Global]
+    insecure-flag = {{ .Values.vcenter.insecurehost | quote }}
+    port = {{ .Values.vcenter.port | quote }}
+    secret-name = "cpi-global-secret"
+    secret-namespace = "kube-system"
+
+    [VirtualCenter {{ .Values.vcenter.host | quote }}]
+    datacenters = {{ .Values.vcenter.datacenter | quote }}

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/csi-driver-rbac.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/csi-driver-rbac.yaml
@@ -1,0 +1,54 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "pods", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvspherevolumemigrations"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/csi-vsphere-config-secret.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/csi-vsphere-config-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-config-secret
+  namespace: kube-system
+type: Opaque
+stringData:
+  csi-vsphere.conf: |-
+    [Global]
+    cluster-id = "cluster-{{ randAlpha 5 | lower }}"
+  
+    [VirtualCenter {{ .Values.vcenter.host | quote }}]
+    insecure-flag = {{ .Values.vcenter.insecurehost | quote }}
+    user = {{ .Values.vcenter.username | quote }}
+    password = {{ .Values.vcenter.password | quote }}
+    port = {{ .Values.vcenter.port | quote }}
+    datacenters = {{ .Values.vcenter.datacenter | quote }}

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/storageclass.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/storageclass.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.storageclass  }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+ name: {{ .Values.storageclass.name }}
+ annotations:
+  storageclass.kubernetes.io/is-default-class: {{ .Values.storageclass.default | quote }}
+provisioner: csi.vsphere.vmware.com
+parameters:
+ fstype: {{ .Values.storageclass.fstype }}
+ {{- if .Values.storageclass.datastoreurl  }}
+ DatastoreURL: {{ .Values.storageclass.datastoreurl | quote }}
+ {{- end }}
+ {{- if .Values.storageclass.storagepolicyname }}
+ storagepolicyname: {{ .Values.storageclass.storagepolicyname | quote }}
+ {{- end }}
+{{- if .Values.storageclass.reclaimpolicy }}
+reclaimPolicy: {{ .Values.storageclass.reclaimpolicy }}
+{{- end }}
+{{- end }}

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/vsphere-csi-controller-deployment.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/vsphere-csi-controller-deployment.yaml
@@ -1,0 +1,177 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      serviceAccountName: vsphere-csi-controller
+      nodeSelector:
+        {{- if .Values.csiController.nodeSelector }}
+        {{- toYaml .Values.csiController.nodeSelector | nindent 8 }}
+        {{- else }}
+        node-role.kubernetes.io/controlplane: "true"
+        {{- end }}
+      tolerations:
+        {{- if .Values.csiController.tolerations }}
+        {{- toYaml .Values.csiController.tolerations | nindent 8 }}
+        {{- else }}
+        - key: node-role.kubernetes.io/controlplane
+          value: "true"
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/etcd
+          value: "true"
+          effect: NoExecute
+        {{- end }}
+      dnsPolicy: "Default"
+      containers:
+        - name: csi-attacher
+          image: {{ .Values.images.csiAttacher }}
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-resizer
+          image: {{ .Values.images.csiResizer }}
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-csi-controller
+          image: {{ .Values.images.csiDriver }}
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+        - name: liveness-probe
+          image: {{ .Values.images.livenessProbe }}
+          args:
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: vsphere-syncer
+          image: {{ .Values.images.vsphereSyncer }}
+          args:
+            - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+        - name: csi-provisioner
+          image: {{ .Values.images.csiProvisioner }}
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--default-fstype=ext4"
+            # needed only for topology aware setup
+            #- "--feature-gates=Topology=true"
+            #- "--strict-topology"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+      - name: vsphere-config-volume
+        secret:
+          secretName: vsphere-config-secret
+      - name: socket-dir
+        emptyDir: {}
+---
+apiVersion: v1
+data:
+  "csi-migration": "false" # csi-migration feature is only available for vSphere 7.0U1
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
+  namespace: kube-system
+---
+apiVersion: storage.k8s.io/v1 # For k8s 1.17 or lower use storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.vsphere.vmware.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+---

--- a/charts/vsphere-cpi-csi/v2.3.0/templates/vsphere-csi-node-ds.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/templates/vsphere-csi-node-ds.yaml
@@ -1,0 +1,138 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: vsphere-csi-node
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-node
+        role: vsphere-csi
+    spec:
+      dnsPolicy: "Default"
+      containers:
+      - name: node-driver-registrar
+        image: {{ .Values.images.nodeDriverRegistrar }}
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+        - "--health-port=9809"
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: {{ .Values.kubelet.path }}/plugins/csi.vsphere.vmware.com/csi.sock
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        - name: registration-dir
+          mountPath: /registration
+        ports:
+        - containerPort: 9809
+          name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+      - name: vsphere-csi-node
+        image: {{ .Values.images.csiDriver }}
+        args:
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
+        imagePullPolicy: "Always"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: X_CSI_MODE
+          value: "node"
+        - name: X_CSI_SPEC_REQ_VALIDATION
+          value: "false"
+        # needed only for topology aware setups
+        #- name: VSPHERE_CSI_CONFIG
+        #  value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
+        - name: X_CSI_DEBUG
+          value: "true"
+        - name: LOGGER_LEVEL
+          value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        # needed only for topology aware setups
+        #- name: vsphere-config-volume
+        #  mountPath: /etc/cloud
+        #  readOnly: true
+        - name: plugin-dir
+          mountPath: /csi
+        - name: pods-mount-dir
+          mountPath: {{ .Values.kubelet.path }}
+          # needed so that any mounts setup inside this container are
+          # propagated back to the host machine.
+          mountPropagation: "Bidirectional"
+        - name: device-dir
+          mountPath: /dev
+        ports:
+          - containerPort: 9808
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+      - name: liveness-probe
+        image: {{ .Values.images.livenessProbe }}
+        args:
+          - "--v=4"
+          - "--csi-address=/csi/csi.sock"
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+      volumes:
+      # needed only for topology aware setups
+      #- name: vsphere-config-volume
+      #  secret:
+      #    secretName: vsphere-config-secret
+      - name: registration-dir
+        hostPath:
+          path: {{ .Values.kubelet.path }}/plugins_registry
+          type: Directory
+      - name: plugin-dir
+        hostPath:
+          path: {{ .Values.kubelet.path }}/plugins/csi.vsphere.vmware.com
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: {{ .Values.kubelet.path }}
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists

--- a/charts/vsphere-cpi-csi/v2.3.0/values.yaml
+++ b/charts/vsphere-cpi-csi/v2.3.0/values.yaml
@@ -1,0 +1,52 @@
+images:
+  vsphereCloudControllerManager: "gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.1.0"
+  csiAttacher: "quay.io/k8scsi/csi-attacher:v3.0.0"
+  csiDriver: "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0"
+  livenessProbe: "quay.io/k8scsi/livenessprobe:v2.1.0"
+  vsphereSyncer: "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0"
+  csiProvisioner: "quay.io/k8scsi/csi-provisioner:v2.0.0"
+  csiResizer: "quay.io/k8scsi/csi-resizer:v1.0.0"
+  nodeDriverRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v2.0.1"
+
+vcenter:
+  # host: vcenter.example.com
+  insecurehost: true
+  # username: admin 
+  # password: root
+  # datacenter: DC1
+
+kubelet:
+  path: /var/lib/kubelet
+
+cloudProvider: {}
+  #nodeSelector:
+  #  node-role.kubernetes.io/controlplane: "true"
+  #tolerations:
+  #- key: node.cloudprovider.kubernetes.io/uninitialized
+  #  value: "true"
+  #  effect: NoSchedule
+  #- key: node-role.kubernetes.io/controlplane
+  #  value: "true"
+  #  effect: NoSchedule
+  #- key: node-role.kubernetes.io/etcd
+  #  value: "true"
+  #  effect: NoExecute
+
+csiController: {}
+  #nodeSelector:
+  #  node-role.kubernetes.io/controlplane: "true"
+  #tolerations:
+  #- key: node-role.kubernetes.io/controlplane
+  #  value: "true"
+  #  effect: NoSchedule
+  #- key: node-role.kubernetes.io/etcd
+  #  value: "true"
+  #  effect: NoExecute
+
+storageclass:
+  name: vsphere-csi
+  default: true
+  fstype: ext4
+  # storagepolicyname: my-storage-policy
+  # datastoreurl: ds:///vmfs/volumes/vsan:528c27f173c2088e-2126e911985dc3aa/
+  # reclaimpolicy: Delete


### PR DESCRIPTION
v2.2.0 added support for controlling taints/tolerations on the Cloud Provider and CSI, doing so by setting expected defaults in `values.yaml` to be overridden.
The issue with this approach is that Helm deep-merges the tree when a user submits their own values-file, resulting in duplicate keys in some cases (which for tolerations may not be an issue, but for the nodeSelector absolutely is).

This version instead provides empty objects in the values-file, with the defaults documented as an example. If/else-cases are then used in the templates to either use defaults, or the user-provided values.

I apologize for not thinking about this issue when minting the previous PR.